### PR TITLE
Moving deployment api to v1

### DIFF
--- a/stable/monochart/templates/cronjob.yml
+++ b/stable/monochart/templates/cronjob.yml
@@ -19,9 +19,7 @@ spec:
     spec:
       template:
         metadata:
-          annotations:
-            iam.amazonaws.com/role: {{ .Values.pod.iam_role }}
-            sidecar.istio.io/inject: "{{ $enabled_istio }}"
+          annotations: {}
           labels:
 {{- if .Values.labels }}{{- range $name, $value := .Values.labels }}{{- if not (empty $value) }}
             {{ $name }}: {{ $value }}

--- a/stable/monochart/templates/deployment.yml
+++ b/stable/monochart/templates/deployment.yml
@@ -18,7 +18,7 @@
 
 {{- if $enabled_deployment }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
This PR moves the apiVersion support to v1. 

Also, we made changes in jobs template to make commands more reliable and provide same features across the entire chart.